### PR TITLE
fix: fix no roles condition

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -8,7 +8,7 @@
       ],
       "warning_message": "**🚨 Attention:** Be cautious of impersonators! The <TEAM_NAME> will never initiate direct messages (DMs) to users.",
       "external_link_required": false,
-      "excluded_roles": ["VIP"],
+      "excluded_roles": [""],
       "required_roles": [""]
     },
     {
@@ -17,8 +17,8 @@
       ],
       "warning_message": "**🚨 Caution:** This message posted contains a link to an external site that isn't affiliated with the <TEAM_NAME> ticketing system.",
       "external_link_required": true,
-      "excluded_roles": ["VIP"],
-      "required_roles": ["unverified"]
+      "excluded_roles": [""],
+      "required_roles": [""]
     }
   ]
 }


### PR DESCRIPTION
This pull request ensures a warning message is thrown when both the `required_roles` and `excluded_roles` config variables are empty. This functionality has been broken since https://github.com/rickstaa/warnings-discord-bot/pull/9.
