### PR TITLE
fix: ensure the role parameters are linked to their keyword rule

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -8,7 +8,7 @@
       ],
       "warning_message": "**🚨 Attention:** Be cautious of impersonators! The <TEAM_NAME> will never initiate direct messages (DMs) to users.",
       "external_link_required": false,
-      "excluded_roles": [""],
+      "excluded_roles": ["VIP"],
       "required_roles": [""]
     },
     {
@@ -18,7 +18,7 @@
       "warning_message": "**🚨 Caution:** This message posted contains a link to an external site that isn't affiliated with the <TEAM_NAME> ticketing system.",
       "external_link_required": true,
       "excluded_roles": [""],
-      "required_roles": [""]
+      "required_roles": ["unverified"]
     }
   ]
 }

--- a/main.go
+++ b/main.go
@@ -108,12 +108,12 @@ func main() {
 
 			// If excluded roles are specified, check if the user has any of them.
 			if len(keywordList.ExcludedRoles) > 0 && hasRole(memberRoles, keywordList.ExcludedRoles) {
-				return // User has an excluded role, skip the warning message.
+				continue // User has an excluded role, skip the warning message.
 			}
 
 			// If required roles are specified, ensure the user has any of them.
 			if len(keywordList.RequiredRoles) > 0 && !hasRole(memberRoles, keywordList.RequiredRoles) {
-				return // User lacks a required role, skip the warning message.
+				continue // User lacks a required role, skip the warning message.
 			}
 
 			// Create a regular expression pattern dynamically for all keywords in the list with case-insensitivity.


### PR DESCRIPTION
This pull request ensures the role parameters are evaluated based on the keyword warning rule they are linked to.
