### PR TITLE
feat: add ability to only trigger on new members

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ Here's a breakdown of the fields:
   - **external_link_required**: A boolean value. If set to `true`, the bot will only issue a warning if the message contains both the specified keywords and an external link.
   - **excluded_roles**: An array of strings. If specified, the bot will not issue a warning if the message author has at least one of the roles in this list.
   - **required_roles**: An array of strings. If specified, the bot will only issue a warning if the message author has at least one of the roles in this list.
+  - **omit_members_older_than_days**: An integer value. If set to a positive number, the bot will not issue a warning if the message author has been a member of the community for more days than the specified value. If set to 0 or a negative number, this rule is ignored.
 
 Please note that all keyword comparisons performed by the bot are case-insensitive.
 
->[!IMPORTANT]\
+> [!IMPORTANT]\
 > When writing regular expressions in the JSON configuration file, remember to escape backslashes. For example, `\b(word)\b` should be written as `\\b(word)\\b`.
 
 ## Contributing

--- a/config/config.json
+++ b/config/config.json
@@ -12,7 +12,10 @@
       "excluded_roles": [
         "VIP"
       ],
-      "required_roles": []
+      "required_roles": [
+        ""
+      ],
+      "omit_members_older_than_days": 0 
     },
     {
       "keywords": [
@@ -23,10 +26,13 @@
       ],
       "warning_message": "**🚨 Caution:** This message posted contains a link to an external site that isn't affiliated with the <TEAM_NAME> ticketing system.",
       "external_link_required": true,
-      "excluded_roles": [ ],
+      "excluded_roles": [
+        ""
+      ],
       "required_roles": [
         "unverified"
-      ]
+      ],
+      "omit_members_older_than_days": 0
     }
   ]
 }


### PR DESCRIPTION
This pull request allows users to omit messages from users who are longer in the community than a specific number of days. Users can use the `omit_members_older_than_days` config variable to do this.
